### PR TITLE
setting hostconfig in containerconfig

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,9 @@ func main() {
 		Image:       "whoa/tiny",
 		AttachStdin: true,
 		Tty:         true,
+		HostConfig: dockerclient.HostConfig{
+			PublishAllPorts: true,
+		},
 	}
 
 	containerID, err := docker.CreateContainer(containerConfig, "foobar", nil)


### PR DESCRIPTION
I noticed that the `PublishAllPorts` was set to fales in vaporeon, despite being set in the hostconfig.  So, I experimented with alternate ways to set it.  

For whatever reason, if you set it in the `ContainerConfig`, carina will expose the ports.
